### PR TITLE
FIX: Ensures it plays nicely with Icon Header Links theme

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,10 +1,11 @@
 .d-header {
   display: grid;
   grid:
-"left-menu logo extra-info header-buttons chat-header-icon search right-menu" auto;
+"left-menu logo extra-info chat-header-icon search right-menu" auto;
   grid-column-gap: 0.2em;
   padding: 0 8px;
   box-sizing: border-box;
+  align-content: center;
 
   & > .wrap {
     &,


### PR DESCRIPTION
Another small tweak. Double-checked, and there were no side-effects from this on desktop mode.

Before:
<img width="493" alt="Screenshot 2024-07-15 at 6 02 27 PM" src="https://github.com/user-attachments/assets/19ee67bb-cbdb-4a16-8638-c48076b113a3">

After:
<img width="496" alt="Screenshot 2024-07-15 at 6 01 54 PM" src="https://github.com/user-attachments/assets/fc8a766f-3e92-4b47-b40a-3268271155f9">

Just this theme, to show nothing wacky happened:
<img width="490" alt="Screenshot 2024-07-15 at 6 22 06 PM" src="https://github.com/user-attachments/assets/ac715153-bfba-4766-adb7-9500135ca6ea">


