### PR TITLE
FIX: Icon order issue when using the Icon header Theme

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -16,7 +16,7 @@
   .panel {
     &,
     & > .d-header-icons {
-      display: flex;
+      display: contents;
     }
   }
 

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,7 +1,7 @@
 .d-header {
   display: grid;
-  grid: 'left-menu logo custom-header-icon-link extra-info chat search right-menu' auto;
-  grid-column-gap: 0.2em;
+  grid-template-areas: 'left-menu logo custom-header-icon-link-1 custom-header-icon-link-2 custom-header-icon-link-3 custom-header-icon-link-4 custom-header-icon-link-5 extra-info chat search right-menu';
+  grid-template-columns: auto auto auto auto auto auto auto auto auto auto;
   padding: 0 8px;
   box-sizing: border-box;
   align-content: center;
@@ -39,9 +39,23 @@
   .chat-header-icon {
     grid-area: chat;
   }
-
-  .custom-header-icon-link {
-    grid-area: custom-header-icon-link;
+  .icon-wrapper{
+    grid-area: custom-header-icon-link-1;
+  }
+  .custom-header-icon-link:nth-child(1) {
+    grid-area: custom-header-icon-link-1;
+  }
+  .custom-header-icon-link:nth-child(2) {
+    grid-area: custom-header-icon-link-2;
+  }
+  .custom-header-icon-link:nth-child(3) {
+    grid-area: custom-header-icon-link-3;
+  }
+  .custom-header-icon-link:nth-child(4) {
+    grid-area: custom-header-icon-link-4;
+  }
+  .custom-header-icon-link:nth-child(5) {
+    grid-area: custom-header-icon-link-5;
   }
 
   // some protection for text-only site titles

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,7 +1,7 @@
 .d-header {
   display: grid;
   grid-template-areas: 'left-menu logo custom-header-icon-link-1 custom-header-icon-link-2 custom-header-icon-link-3 custom-header-icon-link-4 custom-header-icon-link-5 extra-info chat search right-menu';
-  grid-template-columns: auto auto auto auto auto auto auto auto auto auto;
+  grid-template-columns: repeat(11, auto);
   padding: 0 8px;
   box-sizing: border-box;
   align-content: center;
@@ -44,6 +44,7 @@
   }
   .custom-header-icon-link:nth-child(1) {
     grid-area: custom-header-icon-link-1;
+
   }
   .custom-header-icon-link:nth-child(2) {
     grid-area: custom-header-icon-link-2;

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,7 +1,6 @@
 .d-header {
   display: grid;
-  grid:
-"left-menu logo extra-info chat search right-menu" auto;
+  grid: 'left-menu logo custom-header-icon-link extra-info chat search right-menu' auto;
   grid-column-gap: 0.2em;
   padding: 0 8px;
   box-sizing: border-box;
@@ -17,7 +16,7 @@
   .panel {
     &,
     & > .d-header-icons {
-      display: contents;
+      display: flex;
     }
   }
 
@@ -41,10 +40,14 @@
     grid-area: chat;
   }
 
+  .custom-header-icon-link {
+    grid-area: custom-header-icon-link;
+  }
+
   // some protection for text-only site titles
   .title {
     grid-area: logo;
-    @if ($center_logo == "true") {
+    @if ($center_logo == 'true') {
       margin: 0 auto;
     }
     max-width: unset;


### PR DESCRIPTION
**Problem**
There are issues when this theme component is used alongside the `discourse-icon-header-links` theme component, as can be seen here:

![26d8aaa79c139b0fd78a2302b0f29c9c8e08e75a](https://github.com/user-attachments/assets/5afadb3e-d73f-4249-a559-df2e5c6e5320)

 As seen in the image, there are issues with the ordering of these icon/s.
 
 **Solution**
 Add CSS rules to accommodate one or more of these icons when the `left-menu` TC is used in a mobile view

End result:

![imagen](https://github.com/user-attachments/assets/c6ef4617-f1c6-47ce-8a99-fdab5041954b)
