### PR TITLE
FIX: add missing `header-buttons` in `grid-area`

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,7 +1,7 @@
 .d-header {
   display: grid;
   grid:
-"left-menu logo extra-info chat search right-menu" auto;
+"left-menu logo extra-info chat header-buttons search right-menu" auto;
   grid-column-gap: 0.2em;
   padding: 0 8px;
   box-sizing: border-box;


### PR DESCRIPTION
The login button is not inline with other header buttons.

Before:
![Screenshot_20240809_090012 webp](https://github.com/user-attachments/assets/f73acd9c-371f-434e-a998-9380b0eb992e)
After:
![Screenshot_20240809_085909 webp](https://github.com/user-attachments/assets/2a473d30-89f9-45f0-98b1-f366853f562a)
