### PR TITLE
fix left menu and center logo functionality 

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -63,7 +63,7 @@
   .title {
     grid-area: logo;
     @if ($center_logo == 'true') {
-      margin: 0 auto;
+      justify-content: center;
     }
     max-width: unset;
   }

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -15,8 +15,11 @@
 
   .panel {
     &,
-    & > .d-header-icons {
-      display: contents;
+    .header-buttons {
+      &,
+      & > .d-header-icons {
+        display: contents;
+      }
     }
   }
 


### PR DESCRIPTION
FIX: Adapt to [discourse PR 34235](https://github.com/discourse/discourse/pull/34235)

That PR moves the d-header-icons ul under the header-buttons span, which makes this theme compoennt not work anymore.

Before that commit:
<img width="1726" height="822" alt="dom_before" src="https://github.com/user-attachments/assets/70d81328-3eb7-4a94-a28b-9239bd30f4f6" />

->

After that commit:
<img width="1189" height="793" alt="dom_after" src="https://github.com/user-attachments/assets/0b80faa6-99ac-4b00-847a-1877ed053a69" />

Also I find the center logo doesn't work, so I include another commit:
FIX: Use `justify-content: center` instead of `margin: 0 auto` to horizontally center logo

